### PR TITLE
only return the entity names on top level routes

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -25,13 +25,8 @@ router.get('/', async (ctx) => {
 router.get('/:type', async (ctx) => {
   const { type } = ctx.params;
   try {
-    const characterNames = await fs.readdir(dataDirectory(type));
-    ctx.body = await Promise.all(
-      characterNames.map(async (id) => ({
-        id,
-        ...(await getData(type, id, ctx.query.lang)),
-      })),
-    );
+    const entityNames = await fs.readdir(dataDirectory(type));
+    ctx.body = entityNames
   } catch (e) {
     const availableTypes = await fs.readdir(dataDirectory(''));
     ctx.body = {


### PR DESCRIPTION
currently we return all of the data for /{entityType} routes, which could be a large amount of data in the future, so only returning the names is probably a better idea