### PR TITLE
fix: npm run dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node .",
     "build": "tsc",
     "watch": "tsc -w",
-    "dev": "nodemon",
+    "dev": "nodemon src/index.ts",
     "format": "prettier --write .",
     "lint": "eslint . --ext .js,.ts && prettier --check ."
   },
@@ -49,6 +49,7 @@
     "eslint-plugin-import": "^2.22.1",
     "nodemon": "^2.0.6",
     "prettier": "^2.2.0",
+    "ts-node": "^9.0.0",
     "typescript": "^4.1.2"
   },
   "dependencies": {


### PR DESCRIPTION
### Issue
```
/tmp » git clone https://github.com/genshindev/api.git && cd api/
/tmp/api(master) » npm i
[...]
/tmp/api(master*) » npm run dev

> @genshindev/api@1.0.0 dev /private/tmp/api
> nodemon

[nodemon] 2.0.6
[nodemon] to restart at any time, enter `rs`
[nodemon] watching path(s): *.*
[nodemon] watching extensions: js,mjs,json
[nodemon] starting `node dist/index.js`
internal/modules/cjs/loader.js:883
  throw err;
  ^

Error: Cannot find module '/private/tmp/api/dist/index.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
    at Function.Module._load (internal/modules/cjs/loader.js:725:27)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
    at internal/main/run_main_module.js:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
[nodemon] app crashed - waiting for file changes before starting...
```
What happen's nodemon looking for transpiled ts files in dist. But they won't exist on clean clone, nor will be updated while coding (dist/ updated on build only)

### Solution
nodemon should be based on TS files for development purpose, so add ts-node, and watch those.