### PR TITLE
Add reactions to elements info

### DIFF
--- a/assets/data/elements/anemo/en.json
+++ b/assets/data/elements/anemo/en.json
@@ -1,4 +1,11 @@
 {
   "name": "Anemo",
-  "key": "ANEMO"
+  "key": "ANEMO",
+  "reactions": [
+    {
+      "name": "Swirl",
+      "elements": ["Pyro", "Hydro", "Electro", "Cyro"],
+      "description": "When Anemo meets certain other elements, it can trigger Swirl. Swirl can deal elemental DMG, affect beings, and generate further Elemental Reactions."
+    }
+  ]
 }

--- a/assets/data/elements/cryo/en.json
+++ b/assets/data/elements/cryo/en.json
@@ -1,4 +1,21 @@
 {
   "name": "Cryo",
-  "key": "CRYO"
+  "key": "CRYO",
+  "reactions": [
+    {
+      "name": "Melt",
+      "elements": ["Pyro"],
+      "description": "When Cyro meets Pyro, Melt occurs. The effects of Cyro and Pyro will dissipate when Melt occurs.\nMelt itself does not inflict DMG. However, the Pyro or Cyro attack that triggers Melt deals increased DMG."
+    }, 
+    {
+      "name": "Frozen",
+      "elements": ["Hydro"],
+      "description": "When Cyro meets Hydro, Frozen occurs. Frozen beings are rendered immobile, but also become rock-hard."
+    },
+    {
+      "name": "Superconduct",
+      "elements": ["Electro"],
+      "description": "When Cyro meets Electro, Superconduct occurs. Superconduct deals AoE Cyro DMG and significantly decreases Physical RES for the affected being."
+    }
+  ]
 }

--- a/assets/data/elements/dendro/en.json
+++ b/assets/data/elements/dendro/en.json
@@ -1,4 +1,11 @@
 {
   "name": "Dendro",
-  "key": "DENDRO"
+  "key": "DENDRO",
+  "reactions": [
+    {
+      "name": "Burning",
+      "elements": ["Pyro"],
+      "description": "When Dendro meets Pyro, it triggers Burning, which continuously deals Pyro DMG until it wears off."
+    }
+  ]
 }

--- a/assets/data/elements/electro/en.json
+++ b/assets/data/elements/electro/en.json
@@ -1,4 +1,21 @@
 {
   "name": "Electro",
-  "key": "ELECTRO"
+  "key": "ELECTRO",
+  "reactions": [
+    {
+      "name": "Overloaded",
+      "elements": ["Pyro"],
+      "description": "When Electro meets Pyro, Overloaded occurs. The resulting explosion deals AoE Pyro DMG, and tears effortlessly through otherwise sturdy objects."
+    },
+    {
+      "name": "Electro-Charged",
+      "elements": ["Hydro"],
+      "description": "When Electro meets Hydro, Electro-Charged occurs. Electro-Charged continuously deals Electro DMG until it wears off.\nElectricity intermittently arcs off of Electro-Charged beings, shocking Hydro-affected opponents nearby."
+    },
+    {
+      "name": "Superconduct",
+      "elements": ["Cyro"],
+      "description": "When Electro meets Cyro, Superconduct occurs. Superconduct deals AoE Cyro DMG and significantly decreases Physical RES for the affected being."
+    }
+  ]
 }

--- a/assets/data/elements/geo/en.json
+++ b/assets/data/elements/geo/en.json
@@ -1,4 +1,11 @@
 {
   "name": "Geo",
-  "key": "GEO"
+  "key": "GEO",
+  "reactions": [
+    {
+      "name": "Crystallize",
+      "elements": ["Pyro", "Hydro", "Electro", "Cyro"],
+      "description": "When Geo comes into contact with Pyro/Hydro/Electro/Cyro elements, Crystalize will be triggered!"
+    }
+  ]
 }

--- a/assets/data/elements/hydro/en.json
+++ b/assets/data/elements/hydro/en.json
@@ -1,4 +1,21 @@
 {
   "name": "Hydro",
-  "key": "HYDRO"
+  "key": "HYDRO",
+  "reactions": [
+    {
+      "name": "Vaporize",
+      "elements": ["Pyro"],
+      "description": "When Hydro meets Pyro, Vaporize occurs. The effects of Pyro and Hydro will dissipate when Vaporize occurs.\nVaporize itself does not inflict DMG. However, the Pyro or Hydro attack that triggers Vaporize deals increased DMG."
+    },
+    {
+      "name": "Electro-Charged",
+      "elements": ["Electro"],
+      "description": "When Hydro meets Electro, Electro-Charged occurs. Electro-Charged continuously deals Electro DMG until it wears off.\nElectricity intermittently arcs off of Electro-Charged beings, shocking Hydro-affected opponents nearby."
+    },
+    {
+      "name": "Frozen",
+      "elements": ["Cyro"],
+      "description": "When Hydro meets Cyro, Frozen occurs. Frozen beings are rendered immobile, but also become rock-hard."
+    } 
+  ]
 }

--- a/assets/data/elements/pyro/en.json
+++ b/assets/data/elements/pyro/en.json
@@ -1,4 +1,26 @@
 {
   "name": "Pyro",
-  "key": "PYRO"
+  "key": "PYRO",
+  "reactions": [
+    {
+      "name": "Vaporize",
+      "elements": ["Hydro"],
+      "description": "When Pyro meets Hydro, Vaporize occurs. The effects of Pyro and Hydro will dissipate when Vaporize occurs.\nVaporize itself does not inflict DMG. However, the Pyro or Hydro attack that triggers Vaporize deals increased DMG."
+    },
+    {
+      "name": "Overloaded",
+      "elements": ["Electro"],
+      "description": "When Pyro meets Electro, Overloaded occurs. The resulting explosion deals AoE Pyro DMG, and tears effortlessly through otherwise sturdy objects."
+    },
+    {
+      "name": "Burning",
+      "elements": ["Dendro"],
+      "description": "When Pyro meets Dendro, it triggers Burning, which continuously deals Pyro DMG until it wears off."
+    }, 
+    {
+      "name": "Melt",
+      "elements": ["Cyro"],
+      "description": "When Pyro meets Cyro, Melt occurs. The effects of Cyro and Pyro will dissipate when Melt occurs."
+    }
+  ]
 }


### PR DESCRIPTION
Adds `reactions` to the `elements/:element_name` endpoint.

`reactions` is an array containing objects. Each object is an reaction. An reaction contains `name`, `elements` and `description` keys.
The following keys are:
- `name` - [string] Name of the reactions
- `elements` - [array] List of names of elements that can create this reaction
- `description` - [string] The description listed in Genshin Impact under Tutorials > Elements > {reaction name} *(See attachments)*

*(If an reaction had multiple descriptions, an newline (`\n`) is added in between each description)*

I tested these changes locally and everything seems to work and returned the new information correctly. However I was not user whether I should have used keys for the `elements` field instead of their current names. Maybe a maintainer can look at that 😉 
*(Each element has both a `name` and a `key`)*

Source of descriptions: 
![image](https://user-images.githubusercontent.com/63742759/125666463-907471e7-811a-409d-86c0-130e9da4ea17.png)
![image](https://user-images.githubusercontent.com/63742759/125666500-afee34bc-e030-40c8-8638-764ffa025259.png)
![image](https://user-images.githubusercontent.com/63742759/125666543-b56286bd-5a54-4a23-b0da-a8fbe6bb12e8.png)
