### PR TITLE
Add Thundering Pulse 5 star bow

### DIFF
--- a/assets/data/weapons/thundering-pulse/en.json
+++ b/assets/data/weapons/thundering-pulse/en.json
@@ -1,0 +1,10 @@
+{
+  "name": "Thundering Pulse",
+  "type": "Bow",
+  "rarity": 5,
+  "baseAttack": 46,
+  "subStat": "CRIT DMG",
+  "passiveName": "Rule By Thunder",
+  "passiveDesc": "Increases ATK by 20% and grants the might of the Thunder Emblem. At stack levels 1/2/3, the Thunder Emblem increases Normal Attack DMG by 12/24/40%. The character will obtain 1 stack of Thunder Emblem in each of the following scenarios: Normal Attack deals DMG (stack lasts 5s), casting Elemental Skill (stack lasts 10s); Energy is less than 100% (stack disappears when Energy is full). Each stack's duration is calculated independently.",
+  "location": "Gacha"
+}


### PR DESCRIPTION
Data taken from official version 2.0 new weapon overview.

https://genshin-impact.fandom.com/wiki/Thundering_Pulse

![Thundering Pulse](https://static.wikia.nocookie.net/gensin-impact/images/2/25/Weapon_Card_Thundering_Pulse.jpg/revision/latest?cb=20210719124204)