### PR TITLE
fix misspelling of watatsumi island

### DIFF
--- a/assets/data/characters/kokomi/en.json
+++ b/assets/data/characters/kokomi/en.json
@@ -3,7 +3,7 @@
   "vision": "Hydro",
   "weapon": "Catalyst",
   "nation": "Inazuma",
-  "affiliation": "Watasumi Island",
+  "affiliation": "Watatsumi Island",
   "rarity": 5,
   "constellation": "Dracaena Somnolenta",
   "birthday": "0000-02-22",


### PR DESCRIPTION
changed from 'Watasumi' to 'Watatsumi'