### PR TITLE
Add Thoma data, fix Yanfei elemental skill, fix Kokomi vision_key, fix Prototyp Starglitter name

### DIFF
--- a/assets/data/characters/kokomi/en.json
+++ b/assets/data/characters/kokomi/en.json
@@ -90,6 +90,6 @@
       "level": 6
     }
   ],
-  "vision_key": "ANEMO",
+  "vision_key": "HYDRO",
   "weapon_type": "CATALYST"
 }

--- a/assets/data/characters/thoma/en.json
+++ b/assets/data/characters/thoma/en.json
@@ -1,0 +1,170 @@
+{
+    "name": "Thoma",
+    "vision": "Pyro",
+    "weapon": "Polearm",
+    "nation": "Inazuma",
+    "affiliation": "Yashiro Commission Kamisato Clan",
+    "rarity": 4,
+    "constellation": "Rubeum Scutum",
+    "birthday": "0000-01-09",
+    "description": "The housekeeper of the Yashiro Commission's Kamisato Clan, and a well-known \"fixer\" in Inazuma.\nFriendly and approachable, Thoma fits in with the crowd easily wherever he is.\nAt first glance, he seems to be a very easygoing person, but he is in fact very responsible. He has an extraordinarily serious side, be it in his work or his interpersonal communications.",
+    "skillTalents": [
+        {
+            "name": "Swiftshatter Spear",
+            "unlock": "Normal Attack",
+            "description": "Normal Attack\nPerforms up to four consecutive spear strikes.\nCharged Attack\nConsumes a certain amount of Stamina to lunge forward, dealing damage to opponents along the way.\nPlunging Attack\nPlunges from mid-air to strike the ground below, damaging opponents along the path and dealing AoE DMG upon impact.",
+            "upgrades": [
+                {
+                    "name": "1-Hit DMG",
+                    "value": "44.4%"},
+                {
+                    "name": "2-Hit DMG",
+                    "value": "43.6%"
+                },
+                {
+                    "name": "3-Hit DMG",
+                    "value": "26.8%×2"
+                },
+                {
+                    "name": "4-Hit DMG",
+                    "value": "67.4%"
+                },
+                {
+                    "name": "Charged Attack DMG",
+                    "value": "112.7%"
+                },
+                {
+                    "name": "Charged Attack Stamina Cost",
+                    "value": "25"
+                },
+                {
+                    "name": "Plunge DMG",
+                    "value": "63.9%"
+                },
+                {
+                    "name": "Low / High Plunge DMG",
+                    "value": "127.8% / 159.7%"
+                }
+            ],
+            "type": "NORMAL_ATTACK"
+        },
+        {
+            "name": "Blazing Blessing",
+            "unlock": "Elemental Skill",
+            "description": "Thoma vaults forward with his polearm and delivers a flame-filled flying kick that deals AoE Pyro DMG, while also summoning a defensive Blazing Barrier.\nAt the moment of casting, Thoma's Elemental Skill applies Pyro to himself.\nThe DMG Absorption of the Blazing Barrier scales off Thoma's Max HP.\nThe Blazing Barrier has the following traits:\n- Absorbs Pyro DMG 250% more effectively.\n- When a new Blazing Barrier is obtained, the remaining DMG Absorption of an existing Blazing Barrier will stack and its duration will be refreshed.\nThe maximum DMG Absoprtion of the Blazing Barrier will not exceed a certain percentage of Thoma's Max HP.",
+            "upgrades": [
+                {
+                    "name": "Skill DMG",
+                    "value": "146.4%"
+                },
+                {
+                    "name": "Shield DMG Absorption",
+                    "value": "7.2% max hp + 693"
+                },
+                {
+                    "name": "Shield Duration",
+                    "value": "8s"
+                },
+                {
+                    "name": "CD", "value": "15s"
+                }
+            ],
+            "type": "ELEMENTAL_SKILL"
+        },
+        {
+            "name": "Crimson Ooyoroi",
+            "unlock": "Elemental Burst",
+            "description": "Thoma spins his polearm, slicing at his foes with roaring flames that deal AoE Pyro DMG and weave themselves into a Scorching Ooyoroi.\nScorching Ooyoroi\nWhile Scorching Ooyoroi is in effect, the active character's Normal Attacks will trigger Fiery Collapse, dealing AoE Pyro DMG and summoning a Blazing Barrier.\nFiery Collapse can be triggered once every 1s.\nExcept for the amount of DMG they can absorb, the Blazing Barriers created in this way are identical to those created by Thoma's Elemental Skill, Blazing Blessing:\n- Absorbs Pyro DMG 250% more effectively.\n- When a new Blazing Barrier is obtained, the remaining DMG Absorption of an existing Blazing Barrier will stack and its duration will be refreshed.\nThe maximum DMG Absorption of the Blazing Barrier will not exceed a certain percentage of Thoma's Max HP.\nIf Thoma falls, the effects of Scorching Ooyoroi will be cleared.",
+            "upgrades": [
+                {
+                    "name": "Skill DMG",
+                    "value": "88%"
+                },
+                {
+                    "name": "Fiery Collapse DMG",
+                    "value": "58%"
+                },
+                {
+                    "name": "Shield DMG Absorption",
+                    "value": "1.14% max hp + 110"
+                },
+                {
+                    "name": "Shield Duration",
+                    "value": "8s"
+                },
+                {
+                    "name": "Scorching Ooyoroi Duration",
+                    "value": "15s"
+                },
+                {
+                    "name": "CD",
+                    "value": "20s"
+                },
+                {
+                    "name": "Energy Cost",
+                    "value": "80"
+                }
+            ],
+            "type": "ELEMENTAL_BURST"
+        }
+    ],
+    "passiveTalents": [
+        {
+            "name": "Imbricated Armor",
+            "unlock": "Unlocked at Ascension 1",
+            "description": "When your current active character obtains or refreshes a Blazing Barrier, this character's Shield Strength will increase by 5% for 6s.\nThis effect can be triggered once every 0.3 seconds. Max 5 stacks.",
+            "level": 1
+        },
+        {
+            "name": "Flaming Assault",
+            "unlock": "Unlocked at Ascension 4",
+            "description": "DMG dealt by Crimson Ooyoroi's Fiery Collapse is increased by 2.2% of Thoma's Max HP. ",
+            "level": 4
+        },
+        {
+            "name": "Snap and Swing",
+            "unlock": "Unlocked Automatically",
+            "description": "When you fish successfully in Inazuma, Thoma's help grants a 20% chance of scoring a double catch."
+        }
+    ],
+    "constellations": [
+        {
+            "name": "A Comrade's Duty",
+            "unlock": "Constellation Lv. 1",
+            "description": "When a character protected by Thoma's own Blazing Barrier (Thoma excluded) is attacked, Thoma's own Blazing Blessing CD is decreased by 3s, while his own Crimson Ooyoroi's CD is decreased by 3s.\nThis effect can be triggered once every 20s.",
+            "level": 1
+        },
+        {
+            "name": "A Subordinate's Skills",
+            "unlock": "Constellation Lv. 2",
+            "description": "Crimson Ooyoroi's duration is increased by 3s. ",
+            "level": 2
+        },
+        {
+            "name": "Fortified Resolve",
+            "unlock": "Constellation Lv. 3",
+            "description": "Increases the Level of Blazing Blessing by 3.\nMaximum upgrade level is 15. ",
+            "level": 3
+        },
+        {
+            "name": "Long-Term Planning",
+            "unlock": "Constellation Lv. 4",
+            "description": "After using Crimson Ooyoroi, 15 Energy will be restored to Thoma. ",
+            "level": 4
+        },
+        {
+            "name": "Raging Wildfire",
+            "unlock": "Constellation Lv. 5",
+            "description": "Increases the Level of Crimson Ooyoroi by 3.\nMaximum upgrade level is 15.",
+            "level": 5
+        },
+        {
+            "name": "Burning Heart",
+            "unlock": "Constellation Lv. 6",
+            "description": "When a Blazing Barrier is obtained or refreshed, the DMG dealt by all party members' Normal, Charged, and Plunging Attacks is increased by 15% for 6s.",
+            "level": 6
+        }
+    ],
+    "vision_key": "PYRO",
+    "weapon_type": "POLEARM"
+}

--- a/assets/data/characters/yanfei/en.json
+++ b/assets/data/characters/yanfei/en.json
@@ -54,21 +54,17 @@
       "type": "NORMAL_ATTACK"
     },
     {
-      "name": "Jade Screen",
-      "unlock": "Signed Edict",
+      "name": "Signed Edict",
+      "unlock": "Elemental Skill",
       "description": "Summons blistering flames that deal AoE Pyro DMG.\nIf this attack hits an enemy, Yanfei is granted the maximum number of Scarlet Seals.",
       "upgrades": [
         {
-          "name": "Inherited HP",
-          "value": "50.1%"
-        },
-        {
           "name": "Skill DMG",
-          "value": "230%"
+          "value": "169.6%"
         },
         {
           "name": "CD",
-          "value": "12s"
+          "value": "9s"
         }
       ],
       "type": "ELEMENTAL_SKILL"

--- a/assets/data/weapons/prototype-grudge/en.json
+++ b/assets/data/weapons/prototype-grudge/en.json
@@ -1,5 +1,5 @@
 {
-  "name": "Prototype Grudge",
+  "name": "Prototype Starglitter",
   "type": "Polearm",
   "rarity": 4,
   "baseAttack": 42,


### PR DESCRIPTION
Fix Yanfei elemental skill in en.json
Add Thoma data in en.json
Fix Kokomi's "vision_key" from ANEMO to HYDRO
Fix name of prototype-grudge from Prototype Grudge to Prototype Starglitter (as changed in v1.2)