### PR TITLE
fix: praxis talent book info

### DIFF
--- a/assets/data/materials/talent-book/en.json
+++ b/assets/data/materials/talent-book/en.json
@@ -280,7 +280,7 @@
   },
   "praxis": {
     "characters": ["collei", "nilou", "traveler-dendro", "wanderer"],
-    "availability": ["Tuesday", "Friday", "Sunday"],
+    "availability": ["Wednesday", "Saturday", "Sunday"],
     "source": "steeple-of-ignorance",
     "items": [
       {


### PR DESCRIPTION
# Fixing info for Praxis Talent Book
* A copy paste error was made.
* Praxis Talent Books are available on Wednesday, Saturday, Sunday as opposed to Tuesday, Friday, Sunday