### PR TITLE
Repair Dehya JSON

### DIFF
--- a/assets/data/characters/dehya/en.json
+++ b/assets/data/characters/dehya/en.json
@@ -139,7 +139,7 @@
     {
       "name": "The Sunlit Way",
       "unlock": "Unlocked Automatically",
-      "description": "Increases the Movement SPD of your own party members by 10% during the day (6:00 – 18:00).\nDoes not take effect in Domains, Trounce Domains, or Spiral Abyss. Not stackable with Passive Talents that provide the exact same effects."
+      "description": "Increases the Movement SPD of your own party members by 10% during the day (6:00 â€“ 18:00).\nDoes not take effect in Domains, Trounce Domains, or Spiral Abyss. Not stackable with Passive Talents that provide the exact same effects."
     }
   ],
   "constellations": [
@@ -183,5 +183,3 @@
   "vision_key": "PYRO",
   "weapon_type": "CLAYMORE"
 }
-  
-  


### PR DESCRIPTION
It looks like Python has trouble processing the dash symbol in Dehya's JSON file. This PR replaces it with a correct UTF-8 en dash symbol.

The error that Python's built-in JSON module produces with the original file is `UnicodeDecodeError: 'utf-8' codec can't decode byte 0x96 in position 6916: invalid start byte`  when executing code analogous to this:

```python
import json

f = open("assets/data/characters/dehya/en.json")
json_data = json.load(f)
```

