### PR TITLE
Add 4.0 characters

### DIFF
--- a/assets/data/characters/freminet/en.json
+++ b/assets/data/characters/freminet/en.json
@@ -10,7 +10,7 @@
   "release": "2023-09-06",
   "constellation": "Automaton",
   "birthday": "0000-09-24",
-  "description": "\"Did you see that? As the dove emerged from the hat, the corner of Freminet's mouth turned up very slightly. Imagine how he'd react if we could find a way to make a whole flock of them fly out! After all, as his big brother, it's my duty to make him laugh.\"\n— Lyney winked as he discussed with Lynette after a rehearsal.",
+  "description": "A reserved young man who is well-versed in diving. Beneath his distant, icy demeanor lies a pure heart bereft of all flaws.",
   "skillTalents": [
     {
       "name": "Flowing Eddies",

--- a/assets/data/characters/freminet/en.json
+++ b/assets/data/characters/freminet/en.json
@@ -1,0 +1,93 @@
+{
+  "name": "Freminet",
+  "title": "Yearning for Unseen Depths",
+  "vision": "Cryo",
+  "weapon": "Claymore",
+  "gender": "Male",
+  "nation": "Fontaine",
+  "affiliation": "Hotel Bouffes d'ete",
+  "rarity": 4,
+  "release": "2023-09-06",
+  "constellation": "Automaton",
+  "birthday": "0000-09-24",
+  "description": "\"Did you see that? As the dove emerged from the hat, the corner of Freminet's mouth turned up very slightly. Imagine how he'd react if we could find a way to make a whole flock of them fly out! After all, as his big brother, it's my duty to make him laugh.\"\n— Lyney winked as he discussed with Lynette after a rehearsal.",
+  "skillTalents": [
+    {
+      "name": "Flowing Eddies",
+      "unlock": "Normal Attack",
+      "description": "Normal Attack\nPerforms up to 4 consecutive strikes.\nCharged Attack\nDrains Stamina over time to perform continuous spinning attacks against all nearby opponents.\nAt the end of the sequence, performs a more powerful slash.\nPlunging Attack\nPlunges from mid-air to strike the ground below, damaging opponents along the path and dealing AoE DMG upon impact.",
+      "type": "NORMAL_ATTACK"
+    },
+    {
+      "name": "Pressurized Floe",
+      "unlock": "Elemental Skill",
+      "description": "Does an upward thrust that will deal Cryo DMG and cause Freminet to enter Pers Timer for 10s.\nWhile Pers Timer is active, his Elemental Skill will turn into Shattering Pressure.\nShattering Pressure\nExecutes different sorts of attacks based on the Pressure level of Pers Timer, and then cancels Pers Timer.\nLevel 0: Unleashes a vertical cut that will deal Cryo DMG.\nLevels 1 to 3: Unleashes a vertical cut alongside Pers, dealing Cryo DMG and Physical DMG. DMG dealt scales based on Pressure level.\nLevel 4: Borrows the power of a fully-pressurized Pers to deal Physical DMG. Meanwhile, Normal Attack: Flowing Eddies will be replaced by Shattering Pressure.\nPers Timer\nWhen Freminet uses Normal Attacks, he will also unleash waves of frost that deal Cryo DMG and increase Pers' Pressure level.\nThe accompanying Cryo DMG dealt this way is considered Elemental Skill DMG.\nArkhe: Pneuma\nAt certain intervals, after using the upward thrust, a Spiritbreath Thorn in the form of another upward thrust will be created, dealing Pneuma-aligned Cryo DMG.\nTo immobilize one's opponent without taking their life can also be considered something of a \"survival\" strategy that one may choose.\n\"Pers... I leave the rest to you.\"",
+      "type": "ELEMENTAL_SKILL"
+    },
+    {
+      "name": "Shadowhunter's Ambush",
+      "unlock": "Elemental Burst",
+      "description": "Unleashes a wave of untouchable cold, dealing AoE Cryo DMG, resetting the CD of the Elemental Skill \"Pressurized Floe,\" and causing Freminet to enter the Subnautical Hunter mode for 10s.\nWhile in Subnautical Hunter mode, his interruption resistance will increase, and Pressurized Floe will obtain the following buffs:\nCD decreased by 70%.\nNormal Attacks will give Pers 1 additional Pressure stack, and the frost released by his Normal Attacks deal 200% of their original DMG.\nThis effect will be canceled when Freminet leaves the field.\n\"Now... I have no need of any extraneous noise.\"",
+      "type": "ELEMENTAL_BURST"
+    }
+  ],
+  "passiveTalents": [
+    {
+      "name": "Deepwater Navigation",
+      "unlock": "Unlocked at Ascension 1",
+      "description": "Decreases underwater stamina consumption for your own party members by 35%.\nNot stackable with Passive Talents that provide the exact same effects.",
+      "level": 1
+    },
+    {
+      "name": "Saturation Deep Dive",
+      "unlock": "Unlocked at Ascension 4",
+      "description": "When using Pressurized Floe: Shattering Pressure, if Pers Timer has less than 4 levels of Pressure, the CD of Pressurized Floe will be decreased by 1s.",
+      "level": 4
+    },
+    {
+      "name": "Parallel Condensers",
+      "unlock": "Unlocked Automatically",
+      "description": "When Freminet triggers Shatter against opponents, the DMG dealt by Pressurized Floe: Shattering Pressure will be increased by 40% for 5s."
+    }
+  ],
+  "constellations": [
+    {
+      "name": "Dreams of the Foamy Deep",
+      "unlock": "Constellation Lv. 1",
+      "description": "The CRIT Rate of Pressurized Floe: Shattering Pressure will be increased by 15%.",
+      "level": 1
+    },
+    {
+      "name": "Penguins and the Land of Plenty",
+      "unlock": "Constellation Lv. 2",
+      "description": "Unleashing Pressurized Floe: Shattering Pressure will restore 2 Energy to Freminet. If a Pressure Level 4 Shattering Pressure is unleashed, this will restore 3 Energy.",
+      "level": 2
+    },
+    {
+      "name": "Song of the Eddies and Bleached Sands",
+      "unlock": "Constellation Lv. 3",
+      "description": "Increases the Level of Normal Attack: Flowing Eddies by 3.\nMaximum upgrade level is 15.",
+      "level": 3
+    },
+    {
+      "name": "Dance of the Snowy Moon and Flute",
+      "unlock": "Constellation Lv. 4",
+      "description": "When Freminet triggers Frozen, Shatter, or Superconduct against opponents, his ATK will be increased by 9% for 6s. Max 2 stacks. This can be triggered once every 0.3s.",
+      "level": 4
+    },
+    {
+      "name": "Nights of Hearth and Happiness",
+      "unlock": "Constellation Lv. 5",
+      "description": "Increases the Level of Pressurized Floe by 3.\nMaximum upgrade level is 15.",
+      "level": 5
+    },
+    {
+      "name": "Moment of Waking and Resolve",
+      "unlock": "Constellation Lv. 6",
+      "description": "When Freminet triggers Frozen, Shatter, or Superconduct against opponents, his CRIT DMG will be increased by 12% for 6s. Max 3 stacks. This can be triggered once every 0.3s.",
+      "level": 6
+    }
+  ],
+  "vision_key": "CRYO",
+  "weapon_type": "CLAYMORE"
+}

--- a/assets/data/characters/lynette/en.json
+++ b/assets/data/characters/lynette/en.json
@@ -10,7 +10,7 @@
   "release": "2023-08-16",
   "constellation": "Felis Alba",
   "birthday": "0000-02-02",
-  "description": "\"That's already the fifth time this month... Haven't you learned not to mess with Lynette?\"\n— Words muttered by Freminet to a vacuum cleaner, overheard by Lyney as he left his room in the dead of night.",
+  "description": "A magic assistant of few words, her emotions are as inscrutable as any cat's.",
   "skillTalents": [
     {
       "name": "Rapid Ritesword",

--- a/assets/data/characters/lynette/en.json
+++ b/assets/data/characters/lynette/en.json
@@ -1,0 +1,93 @@
+{
+  "name": "Lynette",
+  "title": "Elegance in the Shadows",
+  "vision": "Anemo",
+  "weapon": "Sword",
+  "gender": "Female",
+  "nation": "Fontaine",
+  "affiliation": "Hotel Bouffes d'ete",
+  "rarity": 4,
+  "release": "2023-08-16",
+  "constellation": "Felis Alba",
+  "birthday": "0000-02-02",
+  "description": "\"That's already the fifth time this month... Haven't you learned not to mess with Lynette?\"\n— Words muttered by Freminet to a vacuum cleaner, overheard by Lyney as he left his room in the dead of night.",
+  "skillTalents": [
+    {
+      "name": "Rapid Ritesword",
+      "unlock": "Normal Attack",
+      "description": "Normal Attack\nPerforms up to 4 rapid strikes.\nCharged Attack\nConsumes a certain amount of Stamina to unleash 2 rapid sword strikes.\nPlunging Attack\nPlunges from mid-air to strike the ground below, damaging opponents along the path and dealing AoE DMG upon impact.",
+      "type": "NORMAL_ATTACK"
+    },
+    {
+      "name": "Enigmatic Feint",
+      "unlock": "Elemental Skill",
+      "description": "Flicks her mantle and executes an Enigma Thrust, dealing Anemo DMG.\nWhen the Enigma Thrust hits an opponent, it will restore Lynette's HP based on her Max HP, and in the 4s afterward, she will lose a certain amount of HP per second.\nBased on whether you press or hold this ability, she will use Enigma Thrust differently.\nPress\nShe swiftly uses an Enigma Thrust.\nHold\nLynette will enter a high-speed Pilfering Shadow state and apply Shadowsign to a nearby opponent.\nWhen this high-speed state ends, Lynette will unleash her Enigma Thrust. If there is an opponent with Shadowsign applied to them nearby, Lynette will approach them in a flash before using Enigma Thrust.\nA maximum of 1 opponent can have Shadowsign at any one time. When this opponent gets too far from Lynette, the Shadowsign will be canceled.\nArkhe: Ousia\nAt specific intervals, Lynette will unleash a Surging Blade when she uses Enigma Thrust, dealing Ousia-aligned Anemo DMG.\n\"Now then, turn your eyes to the stage and continue to enjoy the performance. When I next appear, I'll be where you least expect.\"",
+      "type": "ELEMENTAL_SKILL"
+    },
+    {
+      "name": "Magic Trick: Astonishing Shift",
+      "unlock": "Elemental Burst",
+      "description": "Lynette raises her mantle high, dealing AoE Anemo DMG, using skillful sleight of hand to make a giant Bogglecat Box appear!\nBogglecat Box\nTaunts nearby opponents, attracting their attacks.\nDeals Anemo DMG to nearby opponents at intervals.\nWhen the Bogglecat Box comes into contact with Hydro/Pyro/Cryo/Electro, it will gain the corresponding element and additionally fire Vivid Shots that will deal DMG from that element at intervals.\nElemental Absorption of this kind will only occur once during this ability's duration.\n\"Look this way, and look closely. This is a time for miracles, just for us.\"",
+      "type": "ELEMENTAL_BURST"
+    }
+  ],
+  "passiveTalents": [
+    {
+      "name": "Loci-Based Mnemonics",
+      "unlock": "Unlocked at Ascension 1",
+      "description": "Shows the location of nearby Recovery Orbs on the minimap. The underwater Stamina and HP gained from touching Orbs will be increased by 25%.",
+      "level": 1
+    },
+    {
+      "name": "Sophisticated Synergy",
+      "unlock": "Unlocked at Ascension 4",
+      "description": "Within 10s after using Magic Trick: Astonishing Shift, when there are 1/2/3/4 Elemental Types in the party, all party members' ATK will be increased by 8%/12%/16%/20% respectively.",
+      "level": 4
+    },
+    {
+      "name": "Props Positively Prepped",
+      "unlock": "Unlocked Automatically",
+      "description": "After the Bogglecat Box summoned by Magic Trick: Astonishing Shift performs Elemental Conversion, Lynette's Elemental Burst will deal 15% more DMG. This effect will persist until the Bogglecat Box's duration ends."
+    }
+  ],
+  "constellations": [
+    {
+      "name": "A Cold Blade Like a Shadow",
+      "unlock": "Constellation Lv. 1",
+      "description": "When Enigmatic Feint's Enigma Thrust hits an opponent with Shadowsign, a vortex will be created at that opponent's position that will pull nearby opponents in.",
+      "level": 1
+    },
+    {
+      "name": "Endless Mysteries",
+      "unlock": "Constellation Lv. 2",
+      "description": "Whenever the Bogglecat Box summoned by Magic Trick: Astonishing Shift fires a Vivid Shot, it will fire an extra Vivid Shot.",
+      "level": 2
+    },
+    {
+      "name": "Cognition-Inverting Gaze",
+      "unlock": "Constellation Lv. 3",
+      "description": "Increases the Level of Magic Trick: Astonishing Shift by 3.\nMaximum upgrade level is 15.",
+      "level": 3
+    },
+    {
+      "name": "Tacit Coordination",
+      "unlock": "Constellation Lv. 4",
+      "description": "Increases Enigmatic Feint's charges by 1.",
+      "level": 4
+    },
+    {
+      "name": "Obscuring Ambiguity",
+      "unlock": "Constellation Lv. 5",
+      "description": "Increases the Level of Enigmatic Feint by 3.\nMaximum upgrade level is 15.",
+      "level": 5
+    },
+    {
+      "name": "Watchful Eye",
+      "unlock": "Constellation Lv. 6",
+      "description": "When Lynette uses Enigmatic Feint's Enigma Thrust, she will gain an Anemo Infusion and 20% Anemo DMG Bonus for 6s.",
+      "level": 6
+    }
+  ],
+  "vision_key": "ANEMO",
+  "weapon_type": "SWORD"
+}

--- a/assets/data/characters/lyney/en.json
+++ b/assets/data/characters/lyney/en.json
@@ -1,0 +1,93 @@
+{
+  "name": "Lyney",
+  "title": "Spectacle of Phantasmagoria",
+  "vision": "Pyro",
+  "weapon": "Bow",
+  "gender": "Male",
+  "nation": "Fontaine",
+  "affiliation": "Hotel Bouffes d'ete",
+  "rarity": 5,
+  "release": "2023-08-16",
+  "constellation": "Felis Fuscus",
+  "birthday": "0000-02-02",
+  "description": "A famed Fontainian magician who possesses great stage presence as well as gift of the gab. Audiences are enthralled by his exquisite skills, and they hang on to his every clever word.",
+  "skillTalents": [
+    {
+      "name": "Card Force Translocation",
+      "unlock": "Normal Attack",
+      "description": "Normal Attack\nPerforms up to 4 consecutive shots with a bow.\nPlunging Attack\nFires off a shower of arrows in mid-air before falling and striking the ground, dealing AoE DMG upon impact.\nCharged Attack\nPerforms a more precise Aimed Shot with increased DMG.\nWhile aiming, flames will run across the arrowhead before being fired. Different effects will occur based on the time spent charging.\nCharge Level 1: Fires off a Pyro-infused arrow, dealing Pyro DMG.\nCharge Level 2: Fires off a Prop Arrow that deals Pyro DMG, and upon hit, it will summon a Grin-Malkin Hat.\nWhen firing the Prop Arrow, and when Lyney has more than 60% HP, he will consume a portion of his HP to obtain 1 Prop Surplus stack. Max 5 stacks. The effect will be removed after the character spends 30s out of combat.\nThe lowest Lyney can drop to through this method is 60% of his Max HP.\nGrin-Malkin Hat\nCan taunt nearby opponents and attract their attacks. Each opponent can only be taunted by the Hat once every 5s.\nThe Hat will inherit a percentage of Lyney's Max HP.\nIf destroyed, or if its duration expires, it will fire off a Pyrotechnic Strike at 1 nearby opponent, dealing Pyro DMG.\n1 Hat can exist at any given time.\nArkhe: Pneuma\nAt certain intervals, the Prop Arrow will cause a Spiritbreath Thorn to descend upon its hit location, dealing Pneuma-aligned Pyro DMG.",
+      "type": "NORMAL_ATTACK"
+    },
+    {
+      "name": "Bewildering Lights",
+      "unlock": "Elemental Skill",
+      "description": "Lyney does a flourish with his hat, unleashing a firework surprise!\nWhen used, he will clear all current Prop Surplus stacks and deal AoE Pyro DMG to opponents in front of him. DMG will be increased according to the stacks cleared, and this will also regenerate Lyney's HP based on his Max HP.\nWhen a Grin-Malkin Hat created by Lyney is on the field, the fireworks will cause it to explode, dealing AoE Pyro DMG equal to that of a Pyrotechnic Strike.\nThe DMG dealt through the Grin-Malkin Hat in this way is considered Charged Attack DMG.\n\"Everyone knows that magicians will intentionally misdirect the audience... Ah, yes, while you were looking my way, the hat and assistant over there have both disappeared... Fascinating, is it not?\"",
+      "type": "ELEMENTAL_SKILL"
+    },
+    {
+      "name": "Wondrous Trick: Miracle Parade",
+      "unlock": "Elemental Burst",
+      "description": "Unleashing his magic, Lyney turns hinself into a Grin-Malkin Cat that can move around quickly. (Not to be mistaken for the Grin-Malkin Hat. They're two different props!)\nWhen the Grin-Malkin Cat gets close to opponents, it will send flames falling down on them, dealing at most 1 instance of Pyro DMG to each opponent. When the duration ends, he will dismiss the Grin-Malkin Cat and ignite fireworks that deal AoE Pyro DMG, summon 1 Grin-Malkin Hat, and grant himself 1 Prop Surplus stack.\nGrin-Malkin Cat can be actively canceled.\n\"Watch closely now. This is a time for miracles, and it belongs just to the two of us!\"",
+      "type": "ELEMENTAL_BURST"
+    }
+  ],
+  "passiveTalents": [
+    {
+      "name": "Trivial Observations",
+      "unlock": "Unlocked at Ascension 1",
+      "description": "Displays the location of nearby resources unique to Fontaine on the mini-map.",
+      "level": 1
+    },
+    {
+      "name": "Perilous Performance",
+      "unlock": "Unlocked at Ascension 4",
+      "description": "If Lyney consumes HP when firing off a Prop Arrow, the Grin-Malkin hat summoned by the arrow will, upon hitting an opponent, restore 3 Energy to Lyney and increase DMG dealt by 80% of his ATK.",
+      "level": 4
+    },
+    {
+      "name": "Conclusive Ovation",
+      "unlock": "Unlocked Automatically",
+      "description": "When dealing DMG to opponents affected by Pyro, Lyney will receive the following buffs:\nBase ATK increased by 60%.\nEach Pyro party member other than Lyney will cause this effect to receive a further 20% bonus.\nLyney can gain a total of 100% increased DMG to opponents affected by Pyro in this way."
+    }
+  ],
+  "constellations": [
+    {
+      "name": "Whimsical Wonders",
+      "unlock": "Constellation Lv. 1",
+      "description": "Lyney can have 2 Grin-Malkin Hats present at once.\nAdditionally, Prop Arrows will summon 2 Grin-Malkin Hats and grant Lyney 1 extra stack of Prop Surplus. This effect can occur once every 15s.",
+      "level": 1
+    },
+    {
+      "name": "Locquacious Cajoling",
+      "unlock": "Constellation Lv. 2",
+      "description": "When Lyney is on the field, he will gain a stack of Crisp Focus every 2s. This will increase his CRIT DMG by 20%. Max 3 stacks. This effect will be canceled when Lyney leaves the field.",
+      "level": 2
+    },
+    {
+      "name": "Prestidigitation",
+      "unlock": "Constellation Lv. 3",
+      "description": "Increases the Level of Normal Attack: Card Force Translocation by 3.\nMaximum upgrade level is 15.",
+      "level": 3
+    },
+    {
+      "name": "Well-Versed, Well-Rehearsed",
+      "unlock": "Constellation Lv. 4",
+      "description": "After an opponent is hit by Lyney's Pyro Charged Attack, this opponent's Pyro RES will be decreased by 20% for 6s.",
+      "level": 4
+    },
+    {
+      "name": "To Pierce Enigmas",
+      "unlock": "Constellation Lv. 5",
+      "description": "Increases the Level of Wondrous Trick: Miracle Parade by 3.\nMaximum upgrade level is 15.",
+      "level": 5
+    },
+    {
+      "name": "Guarded Smile",
+      "unlock": "Constellation Lv. 6",
+      "description": "When Lyney fires a Prop Arrow, he will fire a Pyrotechnic Strike: Reprised that will deal 80% of a Pyrotechnic Strike's DMG. This DMG is considered Charged Attack DMG.",
+      "level": 6
+    }
+  ],
+  "vision_key": "PYRO",
+  "weapon_type": "BOW"
+}

--- a/assets/data/characters/traveler-hydro/en.json
+++ b/assets/data/characters/traveler-hydro/en.json
@@ -1,0 +1,86 @@
+{
+  "name": "Traveler",
+  "vision": "Hydro",
+  "weapon": "Sword",
+  "nation": "Outlander",
+  "affiliation": "Not affilated to any Nation",
+  "rarity": 5,
+  "release": "2023-08-16",
+  "constellation": "Viator/Viatrix",
+  "birthday": "Unknown",
+  "description": "A traveler from another world who had their only kin taken away, forcing them to embark on a journey to find The Seven.",
+  "skillTalents": [
+    {
+      "name": "Foreign Stream",
+      "unlock": "Normal Attack",
+      "description": "Normal Attack\nPerforms up to 5 rapid strikes.\nCharged Attack\nConsumes a certain amount of Stamina to unleash 2 rapid sword strikes.\nPlunging Attack\nPlunges from mid-air to strike the ground below, damaging opponents along the path and dealing AoE DMG upon impact.",
+      "type": "NORMAL_ATTACK"
+    },
+    {
+      "name": "Aquacrest Saber",
+      "unlock": "Elemental Skill",
+      "description": "Unleashes a torrent that can cleanse the world.\nPress\nSends a Torrent Surge forward that will deal Hydro DMG to opponents it comes into contact with.\nHold\nEnter Aiming Mode and constantly fire off Dewdrops in the direction in which you are aiming, dealing Hydro DMG to opponents they hit.\nWhen the skill ends, it will send a Torrent Surge forward that will deal Hydro DMG to opponents it comes into contact with.\nSuffusion: When using the Hold configuration of this skill, if the Traveler's HP is higher than 50%, the DMG dealt by Dewdrops will increase based on the Traveler's Max HP, and the Traveler will lose a fixed amount of HP every second.\nArkhe: Pneuma\nAt certain intervals, after using Torrent Surge, this skill will unleash a Spiritbreath Thorn that pierces opponents, dealing Pneuma-aligned Hydro DMG.\nYou studied the ripples in the water with Paimon.",
+      "type": "ELEMENTAL_SKILL"
+    },
+    {
+      "name": "Rising Waters",
+      "unlock": "Elemental Burst",
+      "description": "Unleashes a slow-moving floating bubble that deals continuous Hydro DMG to nearby opponents.\nYou studied the ebb and flow of the tides with Paimon.",
+      "type": "ELEMENTAL_BURST"
+    }
+  ],
+  "passiveTalents": [
+    {
+      "name": "Spotless Waters",
+      "unlock": "Unlocked at Ascension 1",
+      "description": "After the Dewdrop fired by the Hold Mode of the Aquacrest Saber hits an opponent, a Sourcewater Droplet will be generated near to the Traveler. If the Traveler picks it up, they will restore 7% HP.\n1 Droplet can be created this way every second, and each use of Aquacrest Saber can create 4 Droplets at most.",
+      "level": 1
+    },
+    {
+      "name": "Clear Waters",
+      "unlock": "Unlocked at Ascension 4",
+      "description": "If HP has been consumed via Suffusion while using the Hold Mode Aquacrest Saber, the Torrent Surge at the skill's end will deal Bonus DMG equal to 45% of the total HP the Traveler has consumed in this skill use via Suffusion.\nThe maximum DMG Bonus that can be gained this way is 5,000.",
+      "level": 4
+    }
+  ],
+  "constellations": [
+    {
+      "name": "Swelling Lake",
+      "unlock": "Constellation Lv. 1",
+      "description": "Picking up a Sourcewater Droplet will restore 2 Energy to the Traveler.\nRequires the Passive Talent \"Spotless Waters.\"",
+      "level": 1
+    },
+    {
+      "name": "Trickling Purity",
+      "unlock": "Constellation Lv. 2",
+      "description": "The Movement SPD of Rising Waters' bubble will be decreased by 30%, and its duration increased by 3s.",
+      "level": 2
+    },
+    {
+      "name": "Turbulent Ripples",
+      "unlock": "Constellation Lv. 3",
+      "description": "Increases the Level of Aquacrest Saber by 3.\nMaximum upgrade level is 15.",
+      "level": 3
+    },
+    {
+      "name": "Pouring Descent",
+      "unlock": "Constellation Lv. 4",
+      "description": "When using Aquacrest Saber, an Aquacrest Aegis that can absorb 10% of the Traveler's Max HP in DMG will be created and will absorb Hydro DMG with 250% effectiveness. It will persist until the Traveler finishes using the skill.\nOnce every 2s, after a Dewdrop hits an opponent, if the Traveler is being protected by Aquacrest Aegis, the DMG Absorption of the Aegis will be restored to 10% of the Traveler's Max HP. If the Traveler is not presently being protected by an Aegis, one will be redeployed.",
+      "level": 4
+    },
+    {
+      "name": "Churning Whirlpool",
+      "unlock": "Constellation Lv. 5",
+      "description": "Increases the Level of Rising Waters by 3.\nMaximum upgrade level is 15.",
+      "level": 5
+    },
+    {
+      "name": "Tides of Justice",
+      "unlock": "Constellation Lv. 6",
+      "description": "When the Traveler picks up a Sourcewater Droplet, they will restore HP to a nearby party member with the lowest remaining HP percentage based on 6% of said member's Max HP.",
+      "level": 6
+    }
+  ],
+  "vision_key": "HYDRO",
+  "weapon_type": "SWORD"
+}


### PR DESCRIPTION
- Lyney, a 5-star character first appearing on a phase 1 banner in 4.0
- Lynette, a 4-star character first appearing on a phase 1 banner in 4.0
- Freminet, a 4-star character first appearing on a phase 2 banner in 4.0
- Hydro Traveller, available for unlock since 4.0 release