### PR TITLE
Bump Node version used in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:21
 WORKDIR /usr/src/app
 
 ARG PORT=5000


### PR DESCRIPTION
Node v16 isn't supported by current version of pnpm. Tested 21 on local machine — everything works