### PR TITLE
fix typo

### DIFF
--- a/assets/data/materials/common-ascension/en.json
+++ b/assets/data/materials/common-ascension/en.json
@@ -1099,7 +1099,7 @@
     "items": [
       {
         "id": "sentry-s-wooden-whistle",
-        "name": "Senry's Wooden Whistle",
+        "name": "Sentry's Wooden Whistle",
         "rarity": 2
       },
       {


### PR DESCRIPTION
materials/common-ascension, line 1102, "name": "Sentry's Wooden Whistle"